### PR TITLE
Introduce alternative backend for hashtree

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,6 +20,7 @@
   {riak_sysmon, {git, "https://github.com/nhs-riak/riak_sysmon.git", {branch, "nhse-develop"}}},
   {clique, {git, "https://github.com/nhs-riak/clique.git", {branch, "nhse-develop"}}},
   {eleveldb, {git, "https://github.com/nhs-riak/eleveldb.git", {branch, "nhse-d30-eldb275"}}},
+  {leveled, {git, "https://github.com/martinsumner/leveled.git", {branch, "mas-d31-i413"}}},
   {riak_ensemble, {git, "https://github.com/nhs-riak/riak_ensemble", {branch, "nhse-develop"}}},
   {pbkdf2, {git, "https://github.com/nhs-riak/erlang-pbkdf2.git", {branch, "nhse-develop"}}},
   {cluster_info, {git, "https://github.com/nhs-riak/cluster_info.git", {branch, "nhse-develop"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,7 @@
   {poolboy, {git, "https://github.com/nhs-riak/poolboy.git", {branch, "nhse-develop-3.2"}}},
   {riak_sysmon, {git, "https://github.com/nhs-riak/riak_sysmon.git", {branch, "nhse-develop"}}},
   {clique, {git, "https://github.com/nhs-riak/clique.git", {branch, "nhse-develop"}}},
-  {eleveldb, {git, "https://github.com/nhs-riak/eleveldb.git", {branch, "nhse-develop"}}},
+  {eleveldb, {git, "https://github.com/nhs-riak/eleveldb.git", {branch, "nhse-d30-eldb275"}}},
   {riak_ensemble, {git, "https://github.com/nhs-riak/riak_ensemble", {branch, "nhse-develop"}}},
   {pbkdf2, {git, "https://github.com/nhs-riak/erlang-pbkdf2.git", {branch, "nhse-develop"}}},
   {cluster_info, {git, "https://github.com/nhs-riak/cluster_info.git", {branch, "nhse-develop"}}},

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -880,16 +880,12 @@ hashes(State, Segments) ->
 -spec snapshot(hashtree()) -> hashtree().
 snapshot(State) ->
     Mod = State#state.database_mod,
-    ?LOG_INFO(
-        "Update snapshot - db ~w snapshot ~w",
-        [State#state.ref, State#state.itr]),
     {ok, Itr} = Mod:snapshot(State#state.ref, State#state.itr),
     State#state{itr=Itr}.
 
 -spec multi_select_segment(
     hashtree(), list('*'|integer()), select_fun(T)) -> [{integer(), T}].
 multi_select_segment(#state{id=Id, itr=Itr, database_mod=Mod}, Segments, F) ->
-    ?LOG_INFO("Multi select segment on snapshot ~w", [Itr]),
     Mod:multi_select_segment(Id, Itr, Segments, F).
 
 

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -113,6 +113,7 @@
          rehash_tree/1,
          flush_buffer/1,
          close/1,
+         close_group/1,
          destroy/1,
          read_meta/2,
          write_meta/3,
@@ -255,6 +256,7 @@ new(TreeId, LinkedStore, Options) ->
             proplist(),
             module()) -> hashtree().
 new({Index,TreeId}, DB, Path, Options, Mod) ->
+    ?LOG_INFO("New segment store ~w for ~w ~w", [DB, TreeId, Index]),
     NumSegments = proplists:get_value(segments, Options, ?NUM_SEGMENTS),
     Width = proplists:get_value(width, Options, ?WIDTH),
     MemLevels = proplists:get_value(mem_levels, Options, ?MEM_LEVELS),
@@ -278,9 +280,19 @@ new({Index,TreeId}, DB, Path, Options, Mod) ->
 -spec close(hashtree()) -> hashtree().
 close(State) ->
     Mod = State#state.database_mod,
+    ?LOG_INFO(
+        "Close store ~w and snapshot ~w for ~w ~w",
+        [State#state.ref, State#state.itr, State#state.id, State#state.index]),
     ok = Mod:close(State#state.ref, State#state.itr),
-    State#state{itr=undefined}.
+    State#state{itr=undefined, ref=undefined}.
 
+-spec close_group(list(hashtree())) -> ok.
+close_group(HashtreeList) ->
+    Head = hd(HashtreeList),
+    Mod = Head#state.database_mod,
+    Mod:close_group(
+        lists:map(fun(S) -> {S#state.ref, S#state.itr} end, HashtreeList)
+    ).
 
 -spec destroy(hashtree()|string()) -> ok.
 destroy(Path) when is_list(Path) ->
@@ -375,6 +387,10 @@ update_snapshot(State=#state{segments=NumSegments}) ->
 
 -spec update_tree(hashtree()) -> hashtree().
 update_tree(State) ->
+    ?LOG_INFO(
+        "Update tree ~w ~w with db ~w snapshot ~w",
+        [State#state.id, State#state.index, State#state.ref, State#state.itr]
+    ),
     State2 = flush_buffer(State),
     State3 = snapshot(State2),
     update_perform(State3).
@@ -864,12 +880,16 @@ hashes(State, Segments) ->
 -spec snapshot(hashtree()) -> hashtree().
 snapshot(State) ->
     Mod = State#state.database_mod,
+    ?LOG_INFO(
+        "Update snapshot - db ~w snapshot ~w",
+        [State#state.ref, State#state.itr]),
     {ok, Itr} = Mod:snapshot(State#state.ref, State#state.itr),
     State#state{itr=Itr}.
 
 -spec multi_select_segment(
     hashtree(), list('*'|integer()), select_fun(T)) -> [{integer(), T}].
 multi_select_segment(#state{id=Id, itr=Itr, database_mod=Mod}, Segments, F) ->
+    ?LOG_INFO("Multi select segment on snapshot ~w", [Itr]),
     Mod:multi_select_segment(Id, Itr, Segments, F).
 
 

--- a/src/hashtree_eleveldb.erl
+++ b/src/hashtree_eleveldb.erl
@@ -1,0 +1,364 @@
+%% -------------------------------------------------------------------
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%% 
+
+-module(hashtree_eleveldb).
+
+-export([
+    new/1,
+    close/2,
+    destroy/1,
+    get/2,
+    mput/2,
+    put/3,
+    delete/2,
+    clear_buckets/2,
+    multi_select_segment/4,
+    snapshot/2,
+    encode_key/1
+    ]).
+
+
+-export([fake_close/1]).
+
+-record(itr_state, {
+    itr                :: term(),
+    id                 :: tree_id_bin(),
+    current_segment    :: '*' | integer(),
+    remaining_segments :: ['*' | integer()],
+    acc_fun            :: fun(([{binary(),binary()}]) -> any()),
+    segment_acc        :: [{binary(), binary()}],
+    final_acc          :: [{integer(), any()}],
+    prefetch=false     :: boolean()
+   }).
+
+-type tree_id_bin() :: <<_:176>>.
+-type bucket_bin()  :: <<_:320>>.
+-type db_key() :: binary().
+-type select_fun(T) :: fun((orddict:orddict()) -> T).
+
+-include_lib("kernel/include/logger.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec new(proplists:proplist()) -> {term(), string()}.
+new(Options) ->
+    DataDir = 
+    case proplists:get_value(segment_path, Options) of
+        undefined ->
+            Root = "/tmp/anti/level",
+            <<P:128/integer>> =
+                riak_core_util:md5(term_to_binary({os:timestamp(), make_ref()})),
+            filename:join(Root, integer_to_list(P));
+        SegmentPath ->
+            SegmentPath
+    end,
+
+    DefaultWriteBufferMin = 4 * 1024 * 1024,
+    DefaultWriteBufferMax = 14 * 1024 * 1024,
+    ConfigVars =
+        hashtree:get_env(
+            anti_entropy_leveldb_opts,
+            [{write_buffer_size_min, DefaultWriteBufferMin},
+                {write_buffer_size_max, DefaultWriteBufferMax}]),
+    Config = orddict:from_list(ConfigVars),
+
+    %% Use a variable write buffer size to prevent against all buffers being
+    %% flushed to disk at once when under a heavy uniform load.
+    WriteBufferMin =
+        proplists:get_value(
+            write_buffer_size_min, Config, DefaultWriteBufferMin),
+    WriteBufferMax =
+        proplists:get_value(
+            write_buffer_size_max, Config, DefaultWriteBufferMax),
+    Offset = rand:uniform(1 + WriteBufferMax - WriteBufferMin),
+    WriteBufferSize = WriteBufferMin + Offset,
+    Config2 = orddict:store(write_buffer_size, WriteBufferSize, Config),
+    Config3 = orddict:erase(write_buffer_size_min, Config2),
+    Config4 = orddict:erase(write_buffer_size_max, Config3),
+    Config5 = orddict:store(is_internal_db, true, Config4),
+    Config6 = orddict:store(use_bloomfilter, true, Config5),
+    StartupOptions = orddict:store(create_if_missing, true, Config6),
+
+    ok = filelib:ensure_dir(DataDir),
+    {ok, Ref} = eleveldb:open(DataDir, StartupOptions),
+    {Ref, DataDir}.
+
+-spec close(term(), term()) -> ok.
+close(DB, Snapshot) ->
+    close_iterator(Snapshot),
+    catch eleveldb:close(DB),
+    ok.
+
+-spec destroy(string()) -> ok.
+destroy(Path) ->
+    eleveldb:destroy(Path, []).
+
+-spec encode_key(
+    {segment, tree_id_bin(), integer(), binary()}|
+    {bucket, tree_id_bin(), integer(), integer()}|
+    {meta, binary()}) -> db_key().
+encode_key({segment, TreeId, Segment, Key}) ->
+    hashtree:external_encode(TreeId, Segment, Key);
+encode_key({bucket, TreeId, Level, Bucket}) ->
+    <<$b,TreeId:22/binary,$b,Level:64/integer,Bucket:64/integer>>;
+encode_key({meta, Key}) ->
+    <<$m,Key/binary>>.
+
+
+-spec snapshot(term(), term()) -> {ok, term()}.
+snapshot(DB, Snapshot) ->
+    %% Abuse eleveldb iterators as snapshots
+    catch eleveldb:iterator_close(Snapshot),
+    eleveldb:iterator(DB, []).
+
+-spec get(term(), db_key()) -> {ok, binary()}| not_found | {error, any()}.
+get(DB, HKey) ->
+    eleveldb:get(DB, HKey, []).
+
+-spec put(term(), db_key(), binary()) -> ok.
+put(DB, HKey, Bin) ->
+    eleveldb:put(DB, HKey, Bin, []).
+
+-spec mput(term(), list({put, db_key(), binary()}|{delete, db_key()})) -> ok.
+mput(DB, Updates) ->
+    eleveldb:write(DB, Updates, []).
+
+-spec delete(term(), db_key()) -> ok.
+delete(DB, HKey) ->
+    eleveldb:delete(DB, HKey, []).
+
+-spec clear_buckets(tree_id_bin(), term()) -> ok.
+clear_buckets(Id, DB) ->
+    Fun = fun({K,_V},Acc) ->
+        try
+            case decode_bucket(K) of
+                {Id, _, _} ->
+                    ok = eleveldb:delete(DB, K, []),
+                    Acc + 1;
+                _ ->
+                    throw({break, Acc})
+            end
+        catch
+            _:_ -> % not a decodable bucket
+                throw({break, Acc})
+        end
+    end,
+    Opts = [{first_key, encode_key({bucket, Id, 0, 0})}],
+    Removed = 
+        try
+            eleveldb:fold(DB, Fun, 0, Opts)
+        catch
+            {break, AccFinal} ->
+                AccFinal
+        end,
+    ?LOG_DEBUG("Tree ~p cleared ~p segments.\n", [Id, Removed]),
+    ok.
+
+
+-spec multi_select_segment(
+    term(), term(), list('*'|integer()), select_fun(T)) -> [{integer(), T}].
+multi_select_segment(Id, Itr, Segments, F) ->
+    [First | Rest] = Segments,
+    IS1 = #itr_state{itr=Itr,
+                     id=Id,
+                     current_segment=First,
+                     remaining_segments=Rest,
+                     acc_fun=F,
+                     segment_acc=[],
+                     final_acc=[]},
+    Seek = case First of
+               '*' ->
+                   encode_key({segment, Id, 0, <<>>});
+               _ ->
+                   encode_key({segment, Id, First, <<>>})
+           end,
+    IS2 = try
+              iterate(iterator_move(Itr, Seek), IS1)
+          after
+              %% Always call prefetch stop to ensure the iterator
+              %% is safe to use in the compare.  Requires
+              %% eleveldb > 2.0.16 or this may segv/hang.
+              _ = iterator_move(Itr, prefetch_stop)
+          end,
+    #itr_state{remaining_segments = LeftOver,
+               current_segment=LastSegment,
+               segment_acc=LastAcc,
+               final_acc=FA} = IS2,
+
+    %% iterate completes without processing the last entries in the state.  Compute
+    %% the final visited segment, and add calls to the F([]) for all of the segments
+    %% that do not exist at the end of the file (due to deleting the last entry in the
+    %% segment).
+    Result = [{LeftSeg, F([])} || LeftSeg <- lists:reverse(LeftOver),
+                  LeftSeg =/= '*'] ++
+    [{LastSegment, F(LastAcc)} | FA],
+    case Result of
+        [{'*', _}] ->
+            %% Handle wildcard select when all segments are empty
+            [];
+        _ ->
+            Result
+    end.
+
+%%%===================================================================
+%%% Internal Functions
+%%%===================================================================
+
+iterator_move(undefined, _Seek) ->
+    {error, invalid_iterator};
+iterator_move(Itr, Seek) ->
+    try
+        eleveldb:iterator_move(Itr, Seek)
+    catch
+        _:badarg ->
+            {error, invalid_iterator}
+    end.
+
+-spec iterate({'error','invalid_iterator'} | {'ok',binary(),binary()},
+              #itr_state{}) -> #itr_state{}.
+
+%% Ended up at an invalid_iterator likely due to encountering a missing dirty
+%% segment - e.g. segment dirty, but removed last entries for it
+iterate({error, invalid_iterator}, IS=#itr_state{current_segment='*'}) ->
+    IS;
+iterate({error, invalid_iterator}, IS=#itr_state{itr=Itr,
+                                                 id=Id,
+                                                 current_segment=CurSeg,
+                                                 remaining_segments=Segments,
+                                                 acc_fun=F,
+                                                 segment_acc=Acc,
+                                                 final_acc=FinalAcc}) ->
+    case Segments of
+        [] ->
+            IS;
+        ['*'] ->
+            IS;
+        [NextSeg | Remaining] ->
+            Seek = encode_key({segment, Id, NextSeg, <<>>}),
+            IS2 = IS#itr_state{current_segment=NextSeg,
+                               remaining_segments=Remaining,
+                               segment_acc=[],
+                               final_acc=[{CurSeg, F(Acc)} | FinalAcc]},
+            iterate(iterator_move(Itr, Seek), IS2)
+    end;
+iterate({ok, K, V}, IS=#itr_state{itr=Itr,
+                                  id=Id,
+                                  current_segment=CurSeg,
+                                  remaining_segments=Segments,
+                                  acc_fun=F,
+                                  segment_acc=Acc,
+                                  final_acc=FinalAcc}) ->
+    {SegId, Seg, _} = safe_decode(K),
+    Segment = case CurSeg of
+                  '*' ->
+                      Seg;
+                  _ ->
+                      CurSeg
+              end,
+    case {SegId, Seg, Segments, IS#itr_state.prefetch} of
+        {bad, -1, _, _} ->
+            %% Non-segment encountered, end traversal
+            IS;
+        {Id, Segment, _, _} ->
+            %% Still reading existing segment
+            IS2 = IS#itr_state{current_segment=Segment,
+                               segment_acc=[{K,V} | Acc],
+                               prefetch=true},
+            iterate(iterator_move(Itr, prefetch), IS2);
+        {Id, _, [Seg|Remaining], _} ->
+            %% Pointing at next segment we are interested in
+            IS2 = IS#itr_state{current_segment=Seg,
+                               remaining_segments=Remaining,
+                               segment_acc=[{K,V}],
+                               final_acc=[{Segment, F(Acc)} | FinalAcc],
+                               prefetch=true},
+            iterate(iterator_move(Itr, prefetch), IS2);
+        {Id, _, ['*'], _} ->
+            %% Pointing at next segment we are interested in
+            IS2 = IS#itr_state{current_segment=Seg,
+                               remaining_segments=['*'],
+                               segment_acc=[{K,V}],
+                               final_acc=[{Segment, F(Acc)} | FinalAcc],
+                               prefetch=true},
+            iterate(iterator_move(Itr, prefetch), IS2);
+        {Id, _, [NextSeg | Remaining], true} ->
+            %% Pointing at uninteresting segment, but need to halt the
+            %% prefetch to ensure the iterator can be reused
+            IS2 = IS#itr_state{current_segment=NextSeg,
+                               segment_acc=[],
+                               remaining_segments=Remaining,
+                               final_acc=[{Segment, F(Acc)} | FinalAcc],
+                               prefetch=true}, % will be after second move
+            _ = iterator_move(Itr, prefetch_stop), % ignore the pre-fetch,
+            Seek = encode_key({segment, Id, NextSeg, <<>>}),      % and risk wasting a reseek
+            iterate(iterator_move(Itr, Seek), IS2);% to get to the next segment
+        {Id, _, [NextSeg | Remaining], false} ->
+            %% Pointing at uninteresting segment, seek to next interesting one
+            Seek = encode_key({segment, Id, NextSeg, <<>>}),
+            IS2 = IS#itr_state{current_segment=NextSeg,
+                               remaining_segments=Remaining,
+                               segment_acc=[],
+                               final_acc=[{Segment, F(Acc)} | FinalAcc]},
+            iterate(iterator_move(Itr, Seek), IS2);
+        {_, _, _, true} ->
+            %% Done with traversal, but need to stop the prefetch to
+            %% ensure the iterator can be reused. The next operation
+            %% with this iterator is a seek so no need to be concerned
+            %% with the data returned here.
+            _ = iterator_move(Itr, prefetch_stop),
+            IS#itr_state{prefetch=false};
+        {_, _, _, false} ->
+            %% Done with traversal
+            IS
+    end.
+
+close_iterator(Itr) ->
+    try
+        eleveldb:iterator_close(Itr)
+    catch
+        _:_ ->
+            ok
+    end.
+
+-spec decode_bucket(bucket_bin()) -> {tree_id_bin(), integer(), integer()}.
+decode_bucket(Bin) ->
+    <<$b,TreeId:22/binary,$b,Level:64/integer,Bucket:64/integer>> = Bin,
+    {TreeId, Level, Bucket}.
+
+-spec safe_decode(binary()) -> {tree_id_bin() | bad, integer(), binary()}.
+safe_decode(Bin) ->
+    case Bin of
+        <<$t,TreeId:22/binary,$s,Segment:64/integer,Key/binary>> ->
+            {TreeId, Segment, Key};
+        _ ->
+            {bad, -1, <<>>}
+    end.
+%%%===================================================================
+%%% EUnit
+%%%===================================================================
+
+
+fake_close(DB) ->
+    catch eleveldb:close(DB).

--- a/src/hashtree_eleveldb.erl
+++ b/src/hashtree_eleveldb.erl
@@ -22,6 +22,7 @@
 -export([
     new/1,
     close/2,
+    close_group/1,
     destroy/1,
     get/2,
     mput/2,
@@ -101,6 +102,10 @@ close(DB, Snapshot) ->
     close_iterator(Snapshot),
     catch eleveldb:close(DB),
     ok.
+
+-spec close_group(list({term(), term()})) -> ok.
+close_group(DBList) ->
+    lists:foreach(fun({DB, Snapshot}) -> close(DB, Snapshot) end, DBList).
 
 -spec destroy(string()) -> ok.
 destroy(Path) ->

--- a/src/hashtree_eleveldb.erl
+++ b/src/hashtree_eleveldb.erl
@@ -64,16 +64,7 @@
 
 -spec new(proplists:proplist()) -> {term(), string()}.
 new(Options) ->
-    DataDir = 
-    case proplists:get_value(segment_path, Options) of
-        undefined ->
-            Root = "/tmp/anti/level",
-            <<P:128/integer>> =
-                riak_core_util:md5(term_to_binary({os:timestamp(), make_ref()})),
-            filename:join(Root, integer_to_list(P));
-        SegmentPath ->
-            SegmentPath
-    end,
+    DataDir = hashtree:get_path(Options),
 
     DefaultWriteBufferMin = 4 * 1024 * 1024,
     DefaultWriteBufferMax = 14 * 1024 * 1024,

--- a/src/hashtree_leveled.erl
+++ b/src/hashtree_leveled.erl
@@ -1,0 +1,234 @@
+%% -------------------------------------------------------------------
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%% 
+
+-module(hashtree_leveled).
+
+-export([
+    new/1,
+    close/2,
+    destroy/1,
+    get/2,
+    mput/2,
+    put/3,
+    delete/2,
+    clear_buckets/2,
+    multi_select_segment/4,
+    snapshot/2,
+    encode_key/1
+    ]).
+
+
+-export([fake_close/1]).
+
+-type tree_id_bin() :: <<_:176>>.
+-type db_key() :: {binary(), binary()}|{{binary(), binary()}, binary()}.
+-type select_fun(T) :: fun((orddict:orddict()) -> T).
+
+-define(HEAD_TAG, h).
+
+-include_lib("kernel/include/logger.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec new(proplists:proplist()) -> {term(), string()}.
+new(Options) ->
+    DataDir = hashtree:get_path(Options),
+
+    LeveledOpts =
+        [
+        {root_path, DataDir},
+        {max_journalobjectcount, 20000},
+            %% one tenth of standard size - as head_only
+        {log_level, warn},
+        {database_id, 0},
+        {head_only, with_lookup},
+        {cache_size, 2000},
+        {sync_strategy, none},
+        {compression_method, native},
+        {compression_point, on_receipt},
+        {snapshot_timeout_short, 3600},
+        {snapshot_timeout_long, 172800}
+            %% Use the 2 days used in kv_index_tictactree
+            %% question over whether in an idle cluster there may be a need for a
+            %% non-finite timeout 
+        ],
+
+    ok = filelib:ensure_dir(DataDir),
+    {ok, DB} = leveled_bookie:book_start(LeveledOpts),
+    {DB, DataDir}.
+
+-spec close(term(), term()) -> ok.
+close(DB, Snapshot) ->
+    close_iterator(Snapshot),
+    catch leveled_bookie:book_close(DB),
+    ok.
+
+-spec destroy(string()) -> ok.
+destroy(Path) ->
+    hashtree:destroy(Path).
+
+-spec encode_key(
+    {segment, tree_id_bin(), integer(), binary()}|
+    {bucket, tree_id_bin(), integer(), integer()}|
+    {meta, binary()}) -> db_key().
+encode_key({segment, TreeId, Segment, Key}) ->
+    {{<<$t, TreeId:22/binary>>, <<Segment:64/integer>>}, <<Key/binary>>};
+encode_key({bucket, TreeId, Level, Bucket}) ->
+    {<<$b, TreeId:22/binary>>, <<Level:64/integer, Bucket:64/integer>>};
+encode_key({meta, Key}) ->
+    {<<$m>>, <<Key/binary>>}.
+
+
+-spec snapshot(term(), term()) -> {ok, term()}.
+snapshot(DB, Snapshot) ->
+    %% Abuse eleveldb iterators as snapshots
+    catch leveled_bookie:book_close(Snapshot),
+    leveled_bookie:book_start([{snapshot_bookie, DB}]).
+
+-spec get(term(), db_key()) -> {ok, binary()}| not_found | {error, any()}.
+get(DB, {Bucket, Key}) ->
+    leveled_bookie:book_headonly(DB, Bucket, Key, null).
+
+-spec put(term(), db_key(), binary()) -> ok.
+put(DB, {Bucket, Key}, Value) ->
+    leveled_bookie:book_mput(
+        DB, [{add, v1, Bucket, Key, null, undefined, Value}]).
+
+-spec mput(term(), list({put, db_key(), binary()}|{delete, db_key()})) -> ok.
+mput(DB, Updates) ->
+    %% Buffer has been built backwards and reversed
+    %% ... so most recent updates are now at the tail of the list
+    %% e.g. [FirstUpdate, SecondUpdate ..., NthUpdate]
+    %% Need to de-duplicate this, so only the most recent change is added for
+    %% each key - so reverse before ukeysort.
+    %% Order expected for leveled is 
+    %% [NthUpdate, ..., SecondUpdate, FirstUpdate] - so don't re-reverse
+    ObjectSpecs =
+        lists:map(
+            fun(Action) ->
+                case Action of
+                    {put, {Bucket, Key}, Value} ->
+                        {add, v1, Bucket, Key, null, undefined, Value};
+                    {delete, {Bucket, Key}} ->
+                        {remove, v1, Bucket, Key, null, undefined, null}
+                end
+            end,
+            lists:ukeysort(2, lists:reverse(Updates))
+        ),
+    leveled_bookie:book_mput(DB, ObjectSpecs).
+
+-spec delete(term(), db_key()) -> ok.
+delete(DB, {Bucket, Key}) ->
+    leveled_bookie:book_mput(
+        DB, [{remove, v1, Bucket, Key, null, undefined, null}]).
+
+-spec clear_buckets(tree_id_bin(), term()) -> ok.
+clear_buckets(Id, DB) ->
+    FoldFun =
+        fun(Bucket, {Key, null}, Acc) ->
+            [{remove, v1, Bucket, Key, null, undefined, null}|Acc]
+        end,
+    {async, BucketFolder} =
+        leveled_bookie:book_keylist(
+            DB,
+            ?HEAD_TAG,
+            element(1, encode_key({bucket, Id, 0, 0})),
+            {FoldFun, []}
+        ),
+    BucketKeyList = BucketFolder(),
+    leveled_bookie:book_mput(DB, BucketKeyList),
+    ?LOG_DEBUG("Tree ~p cleared ~p segments.\n", [Id, length(BucketKeyList)]),
+    ok.
+
+
+-spec multi_select_segment(
+    term(), term(), list('*'|integer()), select_fun(T)) -> [{integer(), T}].
+multi_select_segment(Id, Itr, Segments, F) ->
+    DBType =
+        element(1, element(1, encode_key({segment, Id, 0, <<>>}))),
+    FoldFun =
+        fun(Bucket, {Key, null}, Value, Acc) ->
+            case Bucket of
+                {DBType, <<Seg:64/integer>>} ->
+                    NewEntry = {hashtree:external_encode(Id, Seg, Key), Value},
+                    case Acc of
+                        [] ->
+                            [{Seg, [NewEntry]}];
+                        [{Seg, KVL}|T] ->
+                            [{Seg, [NewEntry|KVL]}|T];
+                        Acc ->
+                            [{Seg, [NewEntry]}|Acc]
+                    end;
+                _ ->
+                    Acc
+            end
+        end,
+    {async, Folder} =
+        case Segments of
+            ['*', '*'] ->
+                leveled_bookie:book_headfold(
+                    Itr, ?HEAD_TAG, {FoldFun, []},
+                    false, false, false
+                );
+            Segments ->
+                BList =
+                    lists:map(
+                        fun(S) ->
+                            element(1, encode_key({segment, Id, S, <<>>}))
+                        end,
+                        Segments
+                    ),
+                leveled_bookie:book_headfold(
+                    Itr, ?HEAD_TAG, {bucket_list, BList}, {FoldFun, []},
+                    false, false, false
+                )
+        end,
+    SegKeyValues = Folder(),
+    Result =
+        lists:map(
+            fun({S, KVL}) -> {S, F(lists:reverse(KVL))} end,
+            SegKeyValues
+        ),
+    lists:reverse(Result).
+
+
+
+%%%===================================================================
+%%% Internal Functions
+%%%===================================================================
+
+
+close_iterator(Itr) ->
+    catch leveled_bookie:book_close(Itr),
+    ok.
+
+
+%%%===================================================================
+%%% EUnit
+%%%===================================================================
+
+
+fake_close(DB) ->
+    catch leveled_bookie:book_close(DB).

--- a/src/hashtree_tree.erl
+++ b/src/hashtree_tree.erl
@@ -193,10 +193,18 @@ new(TreeId, Opts) ->
 %% This deletes the LevelDB files for the nodes.
 -spec destroy(tree()) -> ok.
 destroy(Tree) ->
-    ets:foldl(fun({_, Node}, _) ->
-                      Node1 = hashtree:close(Node),
-                      hashtree:destroy(Node1)
-              end, undefined, Tree#hashtree_tree.nodes),
+    Nodes =
+        ets:foldl(
+            fun({_, Node}, Acc) -> [Node|Acc] end,
+            [],
+            Tree#hashtree_tree.nodes),
+    case Nodes of
+        [] ->
+            ok;
+        Nodes ->
+            ok = hashtree:close_group(Nodes),
+            ok = hashtree:destroy(hd(Nodes))
+    end,
     catch ets:delete(Tree#hashtree_tree.nodes),
     ok.
 


### PR DESCRIPTION
This extracts out the backend (i.e. storage and snapshot) elements of the hashtree implementation into a dedicated module, to make it easier to provide alternative implementations - specifically one which uses leveled not eleveldb.

to make this work effectively an extension of the API is required, whenever a group of hashtrees which potentially share a hashtree store are closed, they should be closed used `hashtree:close_group/1` not looping around the trees calling `hashtree:close/2`.  This is the leveled backend can be closed more efficiently if snapshots are closed prior to the closing the store they are taken from.

https://github.com/nhs-riak/riak_core/issues/1