### PR TITLE
Simplify worker_pool

### DIFF
--- a/src/riak_core_worker_pool.erl
+++ b/src/riak_core_worker_pool.erl
@@ -302,6 +302,7 @@ code_change(_OldVsn, StateName, State, _Extra) ->
     pid(), term(), term(), list(monitor())) -> list(monitor()).
 monitor_worker(Worker, From, Work, Monitors) ->
     Ref = erlang:monitor(process, Worker),
+    %% ukeysort deletes all monitors from Monitors with same worker 
     lists:ukeysort(1, [{Worker, Ref, From, Work} | Monitors]).
 
 -spec demonitor_worker(pid(), list(monitor())) -> list(monitor()). 


### PR DESCRIPTION
Simplify the worker pool by avoiding the shortcut to avoid demonitor/monitor when there is a checking and a queue.

This makes the logic easier to follow, and so resolving the issue with the monitoring of stats becomes more obvious.