### PR TITLE
Remove options specific to client/server

### DIFF
--- a/src/riak_core_ssl_util.erl
+++ b/src/riak_core_ssl_util.erl
@@ -130,36 +130,31 @@ upgrade_client_to_ssl(Socket, App) ->
         false ->
             {error, no_ssl_config};
         Config ->
-            ClientConfig =
-                lists:foldl(
-                    fun(K, CfgAcc) -> 
-                        lists:keydelete(K, 1, CfgAcc)
-                    end,
-                    Config,
-                    server_only_options()),
-            ssl:connect(Socket, ClientConfig)
+            ssl:connect(Socket, deduct_options(Config, server_only_options()))
     end.
 
 client_only_options() ->
     [server_name_indication].
+
+server_only_options() ->
+    [fail_if_no_peer_cert].
+    
+deduct_options(StandardOptions, SpecificOptions) ->
+    lists:foldl(
+        fun(K, CfgAcc) -> 
+            lists:keydelete(K, 1, CfgAcc)
+        end,
+        StandardOptions,
+        SpecificOptions).
 
 upgrade_server_to_ssl(Socket, App) ->
     case maybe_use_ssl(App) of
         false ->
             {error, no_ssl_config};
         Config ->
-            ServerConfig =
-                lists:foldl(
-                    fun(K, CfgAcc) -> 
-                        lists:keydelete(K, 1, CfgAcc)
-                    end,
-                    Config,
-                    client_only_options()),
-            ssl_handshake(Socket, ServerConfig)
+            ssl_handshake(
+                Socket, deduct_options(Config, client_only_options()))
     end.
-
-server_only_options() ->
-    [fail_if_no_peer_cert].
     
 load_certs(undefined) ->
     undefined;

--- a/src/riak_core_ssl_util.erl
+++ b/src/riak_core_ssl_util.erl
@@ -130,17 +130,23 @@ upgrade_client_to_ssl(Socket, App) ->
         false ->
             {error, no_ssl_config};
         Config ->
-            ssl:connect(Socket, Config)
+            ssl:connect(Socket, Config -- server_only_options())
     end.
+
+client_only_options() ->
+    [{server_name_indication, disable}].
 
 upgrade_server_to_ssl(Socket, App) ->
     case maybe_use_ssl(App) of
         false ->
             {error, no_ssl_config};
         Config ->
-            ssl_handshake(Socket, Config)
+            ssl_handshake(Socket, Config -- client_only_options())
     end.
 
+server_only_options() ->
+    [{fail_if_no_peer_cert, true}].
+    
 load_certs(undefined) ->
     undefined;
 load_certs(CertDirOrFile) ->


### PR DESCRIPTION
Server Name Indication is a client-only option - https://www.erlang.org/doc/apps/ssl/ssl.html#t:client_option_cert/0
Fail if No Peer Cert is a server-only option - https://www.erlang.org/doc/apps/ssl/ssl.html#t:server_option_cert/0